### PR TITLE
Update azuredeploy.json to use newer VM size, e.g. B1s

### DIFF
--- a/application-workloads/apache/apache2-on-ubuntu-vm/azuredeploy.json
+++ b/application-workloads/apache/apache2-on-ubuntu-vm/azuredeploy.json
@@ -37,7 +37,7 @@
       "metadata": {
         "description": "Size of the virtual machine"
       },
-      "defaultValue": "Standard_A0"
+      "defaultValue": "Standard_B1s"
     },
     "location": {
       "type": "string",


### PR DESCRIPTION
Standard_A0 VM obsoleted and will not receive additional capacity, so deploy per this VM size will fail in validation.
See more at https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-previous-gen
Suggest to use newer VM size, e.g. "Standard_B1s"

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
